### PR TITLE
Pr 15543

### DIFF
--- a/integration/websockets/e2e/gateway-ack.spec.ts
+++ b/integration/websockets/e2e/gateway-ack.spec.ts
@@ -41,5 +41,38 @@ describe('WebSocketGateway (ack)', () => {
     );
   });
 
+  it('should handle manual ack for async operations when @Ack() is used (success case)', async () => {
+    app = await createNestApp(AckGateway);
+    await app.listen(3000);
+
+    ws = io('http://localhost:8080');
+    const payload = { shouldSucceed: true };
+
+    await new Promise<void>(resolve =>
+      ws.emit('manual-ack', payload, response => {
+        expect(response).to.eql({ status: 'success', data: payload });
+        resolve();
+      }),
+    );
+  });
+
+  it('should handle manual ack for async operations when @Ack() is used (error case)', async () => {
+    app = await createNestApp(AckGateway);
+    await app.listen(3000);
+
+    ws = io('http://localhost:8080');
+    const payload = { shouldSucceed: false };
+
+    await new Promise<void>(resolve =>
+      ws.emit('manual-ack', payload, response => {
+        expect(response).to.eql({
+          status: 'error',
+          message: 'Operation failed',
+        });
+        resolve();
+      }),
+    );
+  });
+
   afterEach(() => app.close());
 });

--- a/integration/websockets/src/ack.gateway.ts
+++ b/integration/websockets/src/ack.gateway.ts
@@ -1,9 +1,29 @@
-import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
+import {
+  Ack,
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+} from '@nestjs/websockets';
 
 @WebSocketGateway(8080)
 export class AckGateway {
   @SubscribeMessage('push')
   onPush() {
     return 'pong';
+  }
+
+  @SubscribeMessage('manual-ack')
+  async handleManualAck(
+    @MessageBody() data: any,
+    @Ack() ack: (response: any) => void,
+  ) {
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    if (data.shouldSucceed) {
+      ack({ status: 'success', data });
+    } else {
+      ack({ status: 'error', message: 'Operation failed' });
+    }
+    return { status: 'ignored' };
   }
 }

--- a/packages/common/enums/route-paramtypes.enum.ts
+++ b/packages/common/enums/route-paramtypes.enum.ts
@@ -12,4 +12,5 @@ export enum RouteParamtypes {
   HOST = 10,
   IP = 11,
   RAW_BODY = 12,
+  ACK = 13,
 }

--- a/packages/common/interfaces/websockets/web-socket-adapter.interface.ts
+++ b/packages/common/interfaces/websockets/web-socket-adapter.interface.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 export interface WsMessageHandler<T = string> {
   message: T;
   callback: (...args: any[]) => Observable<any> | Promise<any>;
+  isAckHandledManually: boolean;
 }
 
 /**

--- a/packages/websockets/context/ws-metadata-constants.ts
+++ b/packages/websockets/context/ws-metadata-constants.ts
@@ -1,6 +1,7 @@
 import { WsParamtype } from '../enums/ws-paramtype.enum';
 
 export const DEFAULT_CALLBACK_METADATA = {
+  [`${WsParamtype.ACK}:2`]: { index: 2, data: undefined, pipes: [] },
   [`${WsParamtype.PAYLOAD}:1`]: { index: 1, data: undefined, pipes: [] },
   [`${WsParamtype.SOCKET}:0`]: { index: 0, data: undefined, pipes: [] },
 };

--- a/packages/websockets/decorators/ack.decorator.ts
+++ b/packages/websockets/decorators/ack.decorator.ts
@@ -1,0 +1,28 @@
+import { WsParamtype } from '../enums/ws-paramtype.enum';
+import { createPipesWsParamDecorator } from '../utils/param.utils';
+
+/**
+ * WebSockets `ack` parameter decorator.
+ * Extracts the `ack` callback function from the arguments of a ws event.
+ *
+ * This decorator signals to the framework that the `ack` callback will be
+ * handled manually within the method, preventing the framework from
+ * automatically sending an acknowledgement based on the return value.
+ *
+ * @example
+ * ```typescript
+ * @SubscribeMessage('events')
+ * onEvent(
+ *   @MessageBody() data: string,
+ *   @Ack() ack: (response: any) => void
+ * ) {
+ *   // Manually call the ack callback
+ *   ack({ status: 'ok' });
+ * }
+ * ```
+ *
+ * @publicApi
+ */
+export function Ack(): ParameterDecorator {
+  return createPipesWsParamDecorator(WsParamtype.ACK)();
+}

--- a/packages/websockets/decorators/index.ts
+++ b/packages/websockets/decorators/index.ts
@@ -3,3 +3,4 @@ export * from './gateway-server.decorator';
 export * from './message-body.decorator';
 export * from './socket-gateway.decorator';
 export * from './subscribe-message.decorator';
+export * from './ack.decorator';

--- a/packages/websockets/enums/ws-paramtype.enum.ts
+++ b/packages/websockets/enums/ws-paramtype.enum.ts
@@ -3,4 +3,5 @@ import { RouteParamtypes } from '@nestjs/common/enums/route-paramtypes.enum';
 export enum WsParamtype {
   SOCKET = RouteParamtypes.REQUEST,
   PAYLOAD = RouteParamtypes.BODY,
+  ACK = RouteParamtypes.ACK,
 }

--- a/packages/websockets/factories/ws-params-factory.ts
+++ b/packages/websockets/factories/ws-params-factory.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { WsParamtype } from '../enums/ws-paramtype.enum';
 
 export class WsParamsFactory {
@@ -14,6 +15,9 @@ export class WsParamsFactory {
         return args[0];
       case WsParamtype.PAYLOAD:
         return data ? args[1]?.[data] : args[1];
+      case WsParamtype.ACK: {
+        return args.find(arg => isFunction(arg));
+      }
       default:
         return null;
     }

--- a/packages/websockets/gateway-metadata-explorer.ts
+++ b/packages/websockets/gateway-metadata-explorer.ts
@@ -10,6 +10,7 @@ import {
 import { NestGateway } from './interfaces/nest-gateway.interface';
 import { ParamsMetadata } from '@nestjs/core/helpers/interfaces';
 import { WsParamtype } from './enums/ws-paramtype.enum';
+import { ContextUtils } from '@nestjs/core/helpers/context-utils';
 
 export interface MessageMappingProperties {
   message: any;
@@ -19,6 +20,7 @@ export interface MessageMappingProperties {
 }
 
 export class GatewayMetadataExplorer {
+  private readonly contextUtils = new ContextUtils();
   constructor(private readonly metadataScanner: MetadataScanner) {}
 
   public explore(instance: NestGateway): MessageMappingProperties[] {
@@ -68,9 +70,12 @@ export class GatewayMetadataExplorer {
     if (!paramsMetadata) {
       return false;
     }
+    const metadataKeys = Object.keys(paramsMetadata);
+    return metadataKeys.some(key => {
+      const type = this.contextUtils.mapParamType(key);
 
-    const params = Object.values(paramsMetadata);
-    return params.some((param: any) => param.type === WsParamtype.ACK);
+      return (Number(type) as WsParamtype) === WsParamtype.ACK;
+    });
   }
 
   public *scanForServerHooks(instance: NestGateway): IterableIterator<string> {

--- a/packages/websockets/test/decorators/ack.decorator.spec.ts
+++ b/packages/websockets/test/decorators/ack.decorator.spec.ts
@@ -1,0 +1,28 @@
+import 'reflect-metadata';
+import { expect } from 'chai';
+import { PARAM_ARGS_METADATA } from '../../constants';
+import { Ack } from '../../decorators/ack.decorator';
+import { WsParamtype } from '../../enums/ws-paramtype.enum';
+
+class AckTest {
+  public test(@Ack() ack: Function) {}
+}
+
+describe('@Ack', () => {
+  it('should enhance class with expected request metadata', () => {
+    const argsMetadata = Reflect.getMetadata(
+      PARAM_ARGS_METADATA,
+      AckTest,
+      'test',
+    );
+
+    const expectedMetadata = {
+      [`${WsParamtype.ACK}:0`]: {
+        index: 0,
+        data: undefined,
+        pipes: [],
+      },
+    };
+    expect(argsMetadata).to.be.eql(expectedMetadata);
+  });
+});

--- a/packages/websockets/test/web-sockets-controller.spec.ts
+++ b/packages/websockets/test/web-sockets-controller.spec.ts
@@ -135,6 +135,7 @@ describe('WebSocketsController', () => {
           message: 'message',
           methodName: 'methodName',
           callback: handlerCallback,
+          isAckHandledManually: false,
         },
       ];
       server = { server: 'test' };
@@ -173,6 +174,7 @@ describe('WebSocketsController', () => {
           message: 'message',
           methodName: 'methodName',
           callback: messageHandlerCallback,
+          isAckHandledManually: false,
         },
       ]);
     });
@@ -188,11 +190,13 @@ describe('WebSocketsController', () => {
           methodName: 'findOne',
           message: 'find',
           callback: null!,
+          isAckHandledManually: false,
         },
         {
           methodName: 'create',
           message: 'insert',
           callback: null!,
+          isAckHandledManually: false,
         },
       ];
       const insertEntrypointDefinitionSpy = sinon.spy(
@@ -413,6 +417,7 @@ describe('WebSocketsController', () => {
       expect(subscribe.called).to.be.true;
     });
   });
+
   describe('subscribeMessages', () => {
     const gateway = new Test();
 
@@ -423,13 +428,39 @@ describe('WebSocketsController', () => {
       client = { on: onSpy, off: onSpy };
 
       handlers = [
-        { message: 'test', callback: { bind: () => 'testCallback' } },
-        { message: 'test2', callback: { bind: () => 'testCallback2' } },
+        {
+          message: 'test',
+          callback: { bind: () => 'testCallback' },
+          isAckHandledManually: true,
+        },
+        {
+          message: 'test2',
+          callback: { bind: () => 'testCallback2' },
+          isAckHandledManually: false,
+        },
       ];
     });
     it('should bind each handler to client', () => {
       instance.subscribeMessages(handlers, client, gateway);
       expect(onSpy.calledTwice).to.be.true;
+    });
+    it('should pass "isAckHandledManually" flag to the adapter', () => {
+      const adapter = config.getIoAdapter();
+      const bindMessageHandlersSpy = sinon.spy(adapter, 'bindMessageHandlers');
+
+      instance.subscribeMessages(handlers, client, gateway);
+
+      const handlersPassedToAdapter = bindMessageHandlersSpy.firstCall.args[1];
+
+      expect(handlersPassedToAdapter[0].message).to.equal(handlers[0].message);
+      expect(handlersPassedToAdapter[0].isAckHandledManually).to.equal(
+        handlers[0].isAckHandledManually,
+      );
+
+      expect(handlersPassedToAdapter[1].message).to.equal(handlers[1].message);
+      expect(handlersPassedToAdapter[1].isAckHandledManually).to.equal(
+        handlers[1].isAckHandledManually,
+      );
     });
   });
   describe('pickResult', () => {

--- a/packages/websockets/test/web-sockets-controller.spec.ts
+++ b/packages/websockets/test/web-sockets-controller.spec.ts
@@ -417,7 +417,6 @@ describe('WebSocketsController', () => {
       expect(subscribe.called).to.be.true;
     });
   });
-
   describe('subscribeMessages', () => {
     const gateway = new Test();
 

--- a/packages/websockets/web-sockets-controller.ts
+++ b/packages/websockets/web-sockets-controller.ts
@@ -72,7 +72,7 @@ export class WebSocketsController {
   ) {
     const nativeMessageHandlers = this.metadataExplorer.explore(instance);
     const messageHandlers = nativeMessageHandlers.map(
-      ({ callback, message, methodName }) => ({
+      ({ callback, isAckHandledManually, message, methodName }) => ({
         message,
         methodName,
         callback: this.contextCreator.create(
@@ -81,6 +81,7 @@ export class WebSocketsController {
           moduleKey,
           methodName,
         ),
+        isAckHandledManually,
       }),
     );
 
@@ -174,10 +175,13 @@ export class WebSocketsController {
     instance: NestGateway,
   ) {
     const adapter = this.config.getIoAdapter();
-    const handlers = subscribersMap.map(({ callback, message }) => ({
-      message,
-      callback: callback.bind(instance, client),
-    }));
+    const handlers = subscribersMap.map(
+      ({ callback, message, isAckHandledManually }) => ({
+        message,
+        callback: callback.bind(instance, client),
+        isAckHandledManually,
+      }),
+    );
     adapter.bindMessageHandlers(client, handlers, data =>
       fromPromise(this.pickResult(data)).pipe(mergeAll()),
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 09:24:01 UTC

This PR introduces manual acknowledgment (ACK) handling for WebSocket gateways in NestJS by adding a new `@Ack()` parameter decorator. The implementation allows developers to manually control when and how acknowledgments are sent in WebSocket communications, rather than relying on the framework's automatic acknowledgment behavior based on return values.

The feature works by:
1. Adding a new `ACK = 13` parameter type to the `RouteParamtypes` enum
2. Creating an `@Ack()` decorator that injects the acknowledgment callback function as a method parameter
3. Introducing an `isAckHandledManually` flag throughout the WebSocket processing pipeline that prevents automatic acknowledgment when set to true
4. Updating the Socket.IO adapter to conditionally skip automatic acknowledgments when manual handling is detected

The change integrates seamlessly with the existing WebSocket architecture by leveraging the established parameter decoration system. When a method uses `@Ack()`, the `GatewayMetadataExplorer` detects this and sets the `isAckHandledManually` flag, which is then propagated through the `WebSocketsController` to the adapter layer. This enables use cases like conditional acknowledgments, async operation handling, and custom error responses where the timing and content of acknowledgments need explicit developer control.

**PR Description Notes:**
- The PR description template is incomplete - no checkboxes are marked and key sections like "What is the current behavior?" and "What is the new behavior?" are empty
- The issue number is listed as "N/A" but this appears to be a significant feature addition that likely relates to community requests or internal planning

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `packages/common/enums/route-paramtypes.enum.ts` | 5/5 | Adds new ACK parameter type to support WebSocket acknowledgment injection |
| `packages/websockets/decorators/ack.decorator.ts` | 5/5 | Creates new `@Ack()` decorator for manual acknowledgment handling |
| `packages/websockets/decorators/index.ts` | 5/5 | Exports the new ACK decorator to make it publicly available |
| `packages/websockets/enums/ws-paramtype.enum.ts` | 5/5 | Adds ACK parameter type mapping to RouteParamtypes for WebSocket contexts |
| `packages/websockets/factories/ws-params-factory.ts` | 4/5 | Implements ACK parameter extraction logic that could fail if multiple functions exist in args |
| `packages/websockets/context/ws-metadata-constants.ts` | 5/5 | Adds default metadata configuration for ACK parameters |
| `packages/websockets/gateway-metadata-explorer.ts` | 3/5 | Adds ACK decorator detection with potential edge cases in type conversion and error handling |
| `packages/websockets/web-sockets-controller.ts` | 5/5 | Threads `isAckHandledManually` flag through the WebSocket processing pipeline |
| `packages/platform-socket.io/adapters/io-adapter.ts` | 3/5 | Updates adapter to skip automatic acknowledgments but lacks error handling for manual ACK failures |
| `packages/common/interfaces/websockets/web-socket-adapter.interface.ts` | 3/5 | Adds required property creating potential breaking change for external adapter implementations |
| `packages/websockets/test/decorators/ack.decorator.spec.ts` | 5/5 | Comprehensive unit tests for the new ACK decorator functionality |
| `packages/websockets/test/gateway-metadata-explorer.spec.ts` | 5/5 | Updates tests to verify ACK decorator detection and metadata handling |
| `packages/websockets/test/web-sockets-controller.spec.ts` | 5/5 | Adds test coverage for the new `isAckHandledManually` flag propagation |
| `integration/websockets/src/ack.gateway.ts` | 5/5 | Adds example implementation demonstrating manual ACK usage patterns |
| `integration/websockets/e2e/gateway-ack.spec.ts` | 5/5 | Integration tests validating manual ACK behavior in success/error scenarios |

</details>

## Confidence score: 3/5

- This PR introduces a well-designed feature but has several potential issues that could cause runtime problems
- Score lowered due to breaking changes in the interface, potential edge cases in metadata exploration, and lack of error handling in manual ACK scenarios
- Pay close attention to `packages/common/interfaces/websockets/web-socket-adapter.interface.ts`, `packages/websockets/gateway-metadata-explorer.ts`, and `packages/platform-socket.io/adapters/io-adapter.ts` for breaking changes and error handling gaps

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Client as "Socket.IO Client"
    participant IoAdapter as "IoAdapter"
    participant Controller as "WebSocketsController"
    participant Gateway as "WebSocket Gateway"
    participant Handler as "Message Handler"

    User->>Client: "Emit message with ack callback"
    Client->>IoAdapter: "Send message with ack function"
    IoAdapter->>IoAdapter: "mapPayload() - Extract data and ack"
    IoAdapter->>Handler: "bindMessageHandlers() - Setup event listener"
    Handler->>Controller: "Message received - transform callback"
    Controller->>Gateway: "Invoke @SubscribeMessage method"
    
    alt Manual Ack (@Ack decorator used)
        Gateway->>Gateway: "Call ack(response) manually in method"
        Note over IoAdapter: "isAckHandledManually = true, skip auto ack"
    else Automatic Ack (no @Ack decorator)
        Gateway->>Handler: "Return response value"
        Handler->>IoAdapter: "Process response"
        IoAdapter->>IoAdapter: "Check isAckHandledManually = false"
        IoAdapter->>Client: "Send automatic acknowledgment"
    end
    
    Client->>User: "Receive acknowledgment response"
```

<!-- /greptile_comment -->