### PR TITLE
Pr 15451

### DIFF
--- a/packages/microservices/exceptions/rpc-exceptions-handler.ts
+++ b/packages/microservices/exceptions/rpc-exceptions-handler.ts
@@ -35,12 +35,6 @@ export class RpcExceptionsHandler extends BaseRpcExceptionFilter {
     exception: T,
     host: ArgumentsHost,
   ): Observable<any> | null {
-    const filters = this.filters.filter(
-      filter => filter.exceptionMetatypes?.length === 0,
-    );
-    if (filters.length > 0) {
-      return filters[0].func(exception, host);
-    }
     if (isEmpty(this.filters)) {
       return null;
     }

--- a/packages/microservices/exceptions/rpc-exceptions-handler.ts
+++ b/packages/microservices/exceptions/rpc-exceptions-handler.ts
@@ -35,6 +35,12 @@ export class RpcExceptionsHandler extends BaseRpcExceptionFilter {
     exception: T,
     host: ArgumentsHost,
   ): Observable<any> | null {
+    const filters = this.filters.filter(
+      filter => filter.exceptionMetatypes?.length === 0,
+    );
+    if (filters.length > 0) {
+      return filters[0].func(exception, host);
+    }
     if (isEmpty(this.filters)) {
       return null;
     }

--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -83,6 +83,10 @@ export class IoAdapter extends AbstractWsAdapter {
     return { data: payload };
   }
 
+  public bindClientDisconnect(client: Socket, callback: Function) {
+    client.on(DISCONNECT_EVENT, (reason: string) => callback(reason));
+  }
+
   public async close(server: Server): Promise<void> {
     if (this.forceCloseConnections && server.httpServer === this.httpServer) {
       return;

--- a/packages/websockets/interfaces/hooks/on-gateway-disconnect.interface.ts
+++ b/packages/websockets/interfaces/hooks/on-gateway-disconnect.interface.ts
@@ -2,5 +2,5 @@
  * @publicApi
  */
 export interface OnGatewayDisconnect<T = any> {
-  handleDisconnect(client: T): any;
+  handleDisconnect(client: T, reason?: string): any;
 }

--- a/packages/websockets/interfaces/nest-gateway.interface.ts
+++ b/packages/websockets/interfaces/nest-gateway.interface.ts
@@ -4,5 +4,5 @@
 export interface NestGateway {
   afterInit?: (server: any) => void;
   handleConnection?: (...args: any[]) => void;
-  handleDisconnect?: (client: any) => void;
+  handleDisconnect?: (client: any, reason?: string) => void;
 }

--- a/packages/websockets/test/web-sockets-controller.spec.ts
+++ b/packages/websockets/test/web-sockets-controller.spec.ts
@@ -412,6 +412,70 @@ describe('WebSocketsController', () => {
       instance.subscribeDisconnectEvent(gateway, event);
       expect(subscribe.called).to.be.true;
     });
+
+    describe('when handling disconnect events', () => {
+      let handleDisconnectSpy: sinon.SinonSpy;
+
+      beforeEach(() => {
+        handleDisconnectSpy = sinon.spy();
+        (gateway as any).handleDisconnect = handleDisconnectSpy;
+      });
+
+      it('should call handleDisconnect with client and reason when data contains both', () => {
+        const mockClient = { id: 'test-client' };
+        const mockReason = 'client namespace disconnect';
+        const disconnectData = { client: mockClient, reason: mockReason };
+
+        let subscriptionCallback: Function | undefined;
+        event.subscribe = (callback: Function) => {
+          subscriptionCallback = callback;
+        };
+
+        instance.subscribeDisconnectEvent(gateway, event);
+
+        if (subscriptionCallback) {
+          subscriptionCallback(disconnectData);
+        }
+
+        expect(handleDisconnectSpy.calledOnce).to.be.true;
+        expect(handleDisconnectSpy.calledWith(mockClient, mockReason)).to.be
+          .true;
+      });
+
+      it('should call handleDisconnect with only client for backward compatibility', () => {
+        const mockClient = { id: 'test-client' };
+
+        let subscriptionCallback: Function | undefined;
+        event.subscribe = (callback: Function) => {
+          subscriptionCallback = callback;
+        };
+
+        instance.subscribeDisconnectEvent(gateway, event);
+
+        if (subscriptionCallback) {
+          subscriptionCallback(mockClient);
+        }
+
+        expect(handleDisconnectSpy.calledOnce).to.be.true;
+        expect(handleDisconnectSpy.calledWith(mockClient)).to.be.true;
+      });
+
+      it('should handle null/undefined data gracefully', () => {
+        let subscriptionCallback: Function | undefined;
+        event.subscribe = (callback: Function) => {
+          subscriptionCallback = callback;
+        };
+
+        instance.subscribeDisconnectEvent(gateway, event);
+
+        if (subscriptionCallback) {
+          subscriptionCallback(null);
+        }
+
+        expect(handleDisconnectSpy.calledOnce).to.be.true;
+        expect(handleDisconnectSpy.calledWith(null)).to.be.true;
+      });
+    });
   });
   describe('subscribeMessages', () => {
     const gateway = new Test();

--- a/packages/websockets/web-sockets-controller.ts
+++ b/packages/websockets/web-sockets-controller.ts
@@ -164,15 +164,22 @@ export class WebSocketsController {
 
   public subscribeDisconnectEvent(instance: NestGateway, event: Subject<any>) {
     if (instance.handleDisconnect) {
-      event.pipe(distinctUntilChanged()).subscribe((data: any) => {
-        // Handle both old format (just client) and new format ({ client, reason })
-        if (data && typeof data === 'object' && 'client' in data) {
-          instance.handleDisconnect!(data.client, data.reason);
-        } else {
-          // Backward compatibility: if it's just the client
-          instance.handleDisconnect!(data);
-        }
-      });
+      event
+        .pipe(
+          distinctUntilChanged((prev, curr) => {
+            const prevClient = prev?.client || prev;
+            const currClient = curr?.client || curr;
+            return prevClient === currClient;
+          }),
+        )
+        .subscribe((data: any) => {
+          if (data && typeof data === 'object' && 'client' in data) {
+            instance.handleDisconnect!(data.client, data.reason);
+          } else {
+            // Backward compatibility: if it's just the client
+            instance.handleDisconnect!(data);
+          }
+        });
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 07:54:17 UTC

This PR enhances WebSocket disconnect handling in NestJS by adding optional `reason` parameter support throughout the WebSocket infrastructure. The changes create a consistent API where disconnect handlers can receive information about why a client disconnected (e.g., network error, intentional disconnect, timeout).

The PR modifies five key files in the websockets module:

1. **Interface Updates**: Both `OnGatewayDisconnect` and `NestGateway` interfaces now include an optional `reason?: string` parameter in their `handleDisconnect` methods
2. **Controller Enhancement**: The `WebSocketsController` is updated to pass disconnect reason information while maintaining backward compatibility with existing implementations
3. **Socket.IO Adapter**: The `IoAdapter` now includes a `bindClientDisconnect` method that properly captures and forwards the disconnect reason from Socket.IO events
4. **Test Coverage**: Comprehensive tests ensure the new functionality works correctly and maintains backward compatibility

This change aligns the NestJS WebSocket interfaces with the underlying Socket.IO capabilities, which already provide disconnect reasons. The implementation is designed to be fully backward compatible - existing gateways that don't use the reason parameter will continue to work unchanged, while new implementations can access this valuable debugging and logging information.

The enhancement integrates seamlessly with the existing WebSocket architecture, where the `WebSocketsController` already had infrastructure to handle disconnect events, and the Socket.IO adapter naturally provides reason information that was previously being discarded.

PR Description Notes:
- The PR description template is incomplete with no checkboxes marked and empty sections for current/new behavior
- Missing description of the actual changes being made

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| packages/websockets/interfaces/hooks/on-gateway-disconnect.interface.ts | 5/5 | Adds optional `reason` parameter to the `handleDisconnect` method signature |
| packages/websockets/interfaces/nest-gateway.interface.ts | 5/5 | Aligns interface with `OnGatewayDisconnect` by adding optional `reason` parameter |
| packages/websockets/web-sockets-controller.ts | 4/5 | Implements disconnect reason handling with backward compatibility logic |
| packages/platform-socket.io/adapters/io-adapter.ts | 4/5 | Adds `bindClientDisconnect` method to capture Socket.IO disconnect reasons |
| packages/websockets/test/web-sockets-controller.spec.ts | 5/5 | Comprehensive test coverage for new disconnect handling functionality |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it maintains full backward compatibility while adding useful functionality
- Score reflects well-structured implementation with comprehensive testing and careful attention to backward compatibility
- No files require special attention as all changes are well-implemented with proper safeguards

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Client as "WebSocket Client"
    participant Adapter as "IoAdapter"
    participant Controller as "WebSocketsController"
    participant Gateway as "NestGateway"
    
    User->>Client: "Initiates disconnect"
    Client->>Adapter: "Emits DISCONNECT_EVENT"
    Adapter->>Controller: "bindClientDisconnect callback(reason)"
    Controller->>Controller: "disconnect.next({ client, reason })"
    Controller->>Gateway: "handleDisconnect(client, reason)"
    Gateway-->>User: "Disconnect handling complete"
```

<!-- /greptile_comment -->